### PR TITLE
fix prepare sample application page url

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorial/prepare-sample-application.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorial/prepare-sample-application.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "サンプルアプリケーションの準備"
-slug: "prepare-sample-application"
+slug: "prepare-the-sample-application"
 excerpt: "シンプルなWebチャットアプリケーションをSaaS化してみましょう"
 hidden: false
 createdAt: "Wed Jan 11 2023 03:12:42 GMT+0000 (Coordinated Universal Time)"


### PR DESCRIPTION
英語版および現在のReadMeのURLに合わせて `prepare-the-sample-application` に修正