### PR TITLE
OGPの画像削除

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       // Replace with your project's social card
-      image: 'img/docusaurus-social-card.jpg',
+      // image: 'img/docusaurus-social-card.jpg',
       navbar: {
         title: '',
         logo: {


### PR DESCRIPTION
OGPの画像がドキュサウルスのものになっているため画像が表示されないようにする


確認
＊検証用のためURLは正しくない
<img width="447" alt="スクリーンショット 2024-02-27 17 59 07" src="https://github.com/Anti-Pattern-Inc/saasus-platform-document/assets/104770122/99c3d120-6e4d-4ba4-a547-aa27bcfa2e9c">
