### PR TITLE
hide ip-restriction

### DIFF
--- a/versioned_sidebars/version-1.6-sidebars.json
+++ b/versioned_sidebars/version-1.6-sidebars.json
@@ -82,8 +82,7 @@
         },
         "saas-development-console/notifymailcustomize",
         "saas-development-console/saasususerinvitation",
-        "saas-development-console/usage-metering",
-        "saas-development-console/ip-restriction"
+        "saas-development-console/usage-metering"
       ]
     },
     {


### PR DESCRIPTION
The page for the IP restriction feature has been hidden since version 1.6.