### PR TITLE
fix: ワークフロー実行時の ESModules エラー対応で CommonJS に変更

### DIFF
--- a/scripts/filter-error-tag.js
+++ b/scripts/filter-error-tag.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Usage: node scripts/filter-error-tag.js <target.yml>
 
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
+const fs = require('fs');
+const yaml = require('js-yaml');
+const path = require('path');
 
 // --- 引数チェック -------------------------------------------------------
 const file = process.argv[2];


### PR DESCRIPTION
# Check List

- [ ] 画像の追加・変更を行っている場合、wikiに記載している [ルール](https://github.com/Anti-Pattern-Inc/saasus-platform-document/wiki/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88%E4%BD%9C%E6%88%90%E3%83%AB%E3%83%BC%E3%83%AB%EF%BC%88%E8%A8%98%E8%BC%89%E4%B8%AD%EF%BC%89)に準拠していることを確認した

GitHub Actions のワークフローから filter-error-tag.js を実行した際に、Node.js が ESModules 構文（import）を解釈できずエラーになったため、require を使った CommonJS 形式に書き換えて対応