### PR TITLE
Integrate Google Analytics via Google Tag Manager

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,9 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        googleTagManager: {
+          containerId: 'GTM-5T68ML2',
+        },
       }),
     ],
     [


### PR DESCRIPTION
npm run start では、Google Analyticsにデータを送信しない。npm run serveした場合は送信する。

# Check List

- [ ] 画像の追加・変更を行っている場合、wikiに記載している [ルール](https://github.com/Anti-Pattern-Inc/saasus-platform-document/wiki/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88%E4%BD%9C%E6%88%90%E3%83%AB%E3%83%BC%E3%83%AB%EF%BC%88%E8%A8%98%E8%BC%89%E4%B8%AD%EF%BC%89)に準拠していることを確認した
