### PR TITLE
API DocsにAnalysis API Schemaと各種APIスキーマの説明リンクを追加

### DIFF
--- a/docs/reference/analysis-api.mdx
+++ b/docs/reference/analysis-api.mdx
@@ -1,0 +1,9 @@
+---
+title: Analysis API
+hide_table_of_contents: true
+sidebar_position: 1
+---
+
+import ApiDocMdx from "@theme/ApiDocMdx";
+
+<ApiDocMdx id="analysisapi-spec" />

--- a/docs/reference/getting-started-with-your-api.md
+++ b/docs/reference/getting-started-with-your-api.md
@@ -28,5 +28,20 @@ APIs pertaining to obtaining, updating, and deleting information related to exte
 [SaaSus Pricing API Schema](/docs/reference/pricing-api)  
 APIs related to pricing units, feature menus, pricing plans, metering unit count, etc.
 
+[SaaSus Communication API Schema](/docs/reference/communication-api)  
+APIs for submitting and retrieving user feedback.
+
+[SaaSus Apilog API Schema](/docs/reference/apilog-api)  
+APIs for retrieving and analyzing API execution logs.
+
+[SaaSus Awsmarketplace API Schema](/docs/reference/awsmarketplace-api)  
+APIs related to AWS Marketplace integration, customer information management, and plan information management.
+
 [SaaSus Integration API Schema](/docs/reference/integration)  
 APIs related to Amazon EventBridge integration.
+
+[SaaSus ApiGateway API Schema](/docs/reference/apigateway-api)  
+APIs for configuring, managing, and publishing API Gateway features.
+
+[SaaSus Analysis API Schema](/docs/reference/analysis-api)  
+APIs for analyzing user behavior history and data collection.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,6 +92,10 @@ const config = {
             spec: "./api/apigatewayapi.yml",
           },
           {
+            id: "analysisapi-spec",
+            spec: "./api/analysisapi.yml",
+          },
+          {
             id: "pricingapi-spec-jpn",
             spec: "./api/pricingapi.jpn.yml",
           },
@@ -122,6 +126,10 @@ const config = {
           {
             id: "apigatewayapi-spec-jpn",
             spec: "./api/apigatewayapi.jpn.yml",
+          },
+          {
+            id: "analysisapi-spec-jpn",
+            spec: "./api/analysisapi.jpn.yml",
           },
         ],
         theme: {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/reference/analysis-api.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/reference/analysis-api.mdx
@@ -1,0 +1,9 @@
+---
+title: Analysis API
+hide_table_of_contents: true
+sidebar_position: 1
+---
+
+import ApiDocMdx from "@theme/ApiDocMdx";
+
+<ApiDocMdx id="analysisapi-spec-jpn" />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/reference/getting-started-with-your-api.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/reference/getting-started-with-your-api.md
@@ -32,6 +32,26 @@ API
 プライシングユニット、機能メニュー、料金プラン、メータリングユニットカウントなど料金に関連するAPI  
 (Pricing-related APIs such as pricing units, feature menus, rate plans, metering unit counts, etc.)
 
+[SaaSus Communication API Schema](/ja/docs/reference/communication-api)  
+ユーザーフィードバックの送信・取得に関するAPI  
+(APIs for submitting and retrieving user feedback)
+
+[SaaSus Apilog API Schema](/ja/docs/reference/apilog-api)  
+API実行ログの取得、分析に関するAPI  
+(APIs for retrieving and analyzing API execution logs)
+
+[SaaSus Awsmarketplace API Schema](/ja/docs/reference/awsmarketplace-api)  
+AWS Marketplace連携、顧客情報管理、プラン情報管理に関するAPI  
+(APIs related to AWS Marketplace integration, customer information management, and plan information management)
+
 [SaaSus Integration API Schema](/ja/docs/reference/integration)  
 Amazon EventBridge 連携に関連するAPI  
 (APIs related to Amazon EventBridge integration)
+
+[SaaSus ApiGateway API Schema](/ja/docs/reference/apigateway-api)  
+API Gateway機能の設定、管理、公開に関するAPI  
+(APIs for configuring, managing, and publishing API Gateway features)
+
+[SaaSus Analysis API Schema](/ja/docs/reference/analysis-api)  
+ユーザー行動履歴の分析、データ収集に関するAPI  
+(APIs for analyzing user behavior history and data collection)

--- a/i18n/ja/docusaurus-plugin-content-docs/version-1.11/reference/analysis-api.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/version-1.11/reference/analysis-api.mdx
@@ -1,0 +1,9 @@
+---
+title: Analysis API
+hide_table_of_contents: true
+sidebar_position: 1
+---
+
+import ApiDocMdx from "@theme/ApiDocMdx";
+
+<ApiDocMdx id="analysisapi-spec-jpn" />

--- a/i18n/ja/docusaurus-plugin-content-docs/version-1.11/reference/getting-started-with-your-api.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/version-1.11/reference/getting-started-with-your-api.md
@@ -32,6 +32,26 @@ API
 プライシングユニット、機能メニュー、料金プラン、メータリングユニットカウントなど料金に関連するAPI  
 (Pricing-related APIs such as pricing units, feature menus, rate plans, metering unit counts, etc.)
 
+[SaaSus Communication API Schema](/ja/docs/reference/communication-api)  
+ユーザーフィードバックの送信・取得に関するAPI  
+(APIs for submitting and retrieving user feedback)
+
+[SaaSus Apilog API Schema](/ja/docs/reference/apilog-api)  
+API実行ログの取得、分析に関するAPI  
+(APIs for retrieving and analyzing API execution logs)
+
+[SaaSus Awsmarketplace API Schema](/ja/docs/reference/awsmarketplace-api)  
+AWS Marketplace連携、顧客情報管理、プラン情報管理に関するAPI  
+(APIs related to AWS Marketplace integration, customer information management, and plan information management)
+
 [SaaSus Integration API Schema](/ja/docs/reference/integration)  
 Amazon EventBridge 連携に関連するAPI  
 (APIs related to Amazon EventBridge integration)
+
+[SaaSus ApiGateway API Schema](/ja/docs/reference/apigateway-api)  
+API Gateway機能の設定、管理、公開に関するAPI  
+(APIs for configuring, managing, and publishing API Gateway features)
+
+[SaaSus Analysis API Schema](/ja/docs/reference/analysis-api)  
+ユーザー行動履歴の分析、データ収集に関するAPI  
+(APIs for analyzing user behavior history and data collection)

--- a/sidebars.js
+++ b/sidebars.js
@@ -458,6 +458,7 @@ const sidebars = {
         "reference/awsmarketplace-api",
         "reference/integration",
         "reference/apigateway-api",
+        "reference/analysis-api",
       ],
     },
   ],

--- a/versioned_docs/version-1.11/reference/analysis-api.mdx
+++ b/versioned_docs/version-1.11/reference/analysis-api.mdx
@@ -1,0 +1,9 @@
+---
+title: Analysis API
+hide_table_of_contents: true
+sidebar_position: 1
+---
+
+import ApiDocMdx from "@theme/ApiDocMdx";
+
+<ApiDocMdx id="analysisapi-spec" />

--- a/versioned_docs/version-1.11/reference/getting-started-with-your-api.md
+++ b/versioned_docs/version-1.11/reference/getting-started-with-your-api.md
@@ -28,5 +28,20 @@ APIs pertaining to obtaining, updating, and deleting information related to exte
 [SaaSus Pricing API Schema](/docs/reference/pricing-api)  
 APIs related to pricing units, feature menus, pricing plans, metering unit count, etc.
 
+[SaaSus Communication API Schema](/docs/reference/communication-api)  
+APIs for submitting and retrieving user feedback.
+
+[SaaSus Apilog API Schema](/docs/reference/apilog-api)  
+APIs for retrieving and analyzing API execution logs.
+
+[SaaSus Awsmarketplace API Schema](/docs/reference/awsmarketplace-api)  
+APIs related to AWS Marketplace integration, customer information management, and plan information management.
+
 [SaaSus Integration API Schema](/docs/reference/integration)  
 APIs related to Amazon EventBridge integration.
+
+[SaaSus ApiGateway API Schema](/docs/reference/apigateway-api)  
+APIs for configuring, managing, and publishing API Gateway features.
+
+[SaaSus Analysis API Schema](/docs/reference/analysis-api)  
+APIs for analyzing user behavior history and data collection.

--- a/versioned_sidebars/version-1.11-sidebars.json
+++ b/versioned_sidebars/version-1.11-sidebars.json
@@ -418,7 +418,8 @@
         "reference/apilog-api",
         "reference/awsmarketplace-api",
         "reference/integration",
-        "reference/apigateway-api"
+        "reference/apigateway-api",
+        "reference/analysis-api"
       ]
     }
   ],


### PR DESCRIPTION
- API DocsにAnalysis API を追加

<img width="2680" height="1320" alt="image" src="https://github.com/user-attachments/assets/88e0d0dc-b268-4615-a248-10082b31b2bf" />

- Getting Startedページの各種APIスキーマの説明リンクを追加
  - SaaSus Communication API Schema
  - SaaSus Apilog API Schema
  - SaaSus Awsmarketplace API Schema
  - SaaSus ApiGateway API Schema
  - SaaSus Analysis API Schema

<img width="2680" height="3960" alt="image" src="https://github.com/user-attachments/assets/8b230e9a-2d62-408c-9f22-c67317693ef6" />


