### PR TITLE
[fix]/callbackに関する注意書きを追記

### DIFF
--- a/docs/tutorial/authentication-preference.mdx
+++ b/docs/tutorial/authentication-preference.mdx
@@ -337,6 +337,10 @@ app.use("/callback", callbackRouter);
 </Tabs>
 ```
 
+:::caution
+In Express, middleware and routes are processed in the order they are registered. Make sure to add `app.use("/callback", callbackRouter)` **before** any 404 catch-all handlers or error handlers in `app.ts`. If a 404 handler is registered first, the `/callback` request will be caught by it and will never reach the callback router, causing a login error.
+:::
+
 To handle GET requests to `/callback`, create `api/routes/callback.ts` and use the `CallbackRouteFunction` provided by the SaaSus SDK.
 
 ```mdx-code-block

--- a/i18n/ja/docusaurus-plugin-content-docs/current/tutorial/authentication-preference.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/tutorial/authentication-preference.mdx
@@ -333,6 +333,10 @@ app.use("/callback", callbackRouter);
 </Tabs>
 ```
 
+:::caution
+Express ではミドルウェアとルートは登録された順番に処理されます。`app.use("/callback", callbackRouter)` は、`app.ts` 内の 404 ハンドラやエラーハンドラよりも**前**に追加してください。404 ハンドラが先に登録されていると、`/callback` へのリクエストが 404 に吸収され、ログイン時にエラーが発生します。
+:::
+
 `api/routes/callback.ts` を作成し、SaaSus SDK が提供する `CallbackRouteFunction` を使って `/callback` の GET リクエストを処理します。
 
 ```mdx-code-block

--- a/i18n/ja/docusaurus-plugin-content-docs/version-1.12/tutorial/authentication-preference.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/version-1.12/tutorial/authentication-preference.mdx
@@ -333,6 +333,10 @@ app.use("/callback", callbackRouter);
 </Tabs>
 ```
 
+:::caution
+Express ではミドルウェアとルートは登録された順番に処理されます。`app.use("/callback", callbackRouter)` は、`app.ts` 内の 404 ハンドラやエラーハンドラよりも**前**に追加してください。404 ハンドラが先に登録されていると、`/callback` へのリクエストが 404 に吸収され、ログイン時にエラーが発生します。
+:::
+
 `api/routes/callback.ts` を作成し、SaaSus SDK が提供する `CallbackRouteFunction` を使って `/callback` の GET リクエストを処理します。
 
 ```mdx-code-block

--- a/versioned_docs/version-1.12/tutorial/authentication-preference.mdx
+++ b/versioned_docs/version-1.12/tutorial/authentication-preference.mdx
@@ -337,6 +337,10 @@ app.use("/callback", callbackRouter);
 </Tabs>
 ```
 
+:::caution
+In Express, middleware and routes are processed in the order they are registered. Make sure to add `app.use("/callback", callbackRouter)` **before** any 404 catch-all handlers or error handlers in `app.ts`. If a 404 handler is registered first, the `/callback` request will be caught by it and will never reach the callback router, causing a login error.
+:::
+
 To handle GET requests to `/callback`, create `api/routes/callback.ts` and use the `CallbackRouteFunction` provided by the SaaSus SDK.
 
 ```mdx-code-block


### PR DESCRIPTION
## 今回の変更背景                                                                                                                                                 
Express の app.ts に /callback ルートを追加する際、404ハンドラより後に記載するとコールバックが404に吸収されログイン時にエラーが発生する不具合が報告され
た。チュートリアルに追加位置の指定がなかったことが原因。
                                                                                                                                                         
## 変更差分 
authentication-preference.mdx（en/ja × current/1.12 の計4ファイル）に、/callback ルートは404ハンドラより前に追加する旨の :::caution を追加。

<img width="1470" height="956" alt="スクリーンショット 2026-04-04 21 54 39" src="https://github.com/user-attachments/assets/1a8d12b2-996d-451a-aee0-926992a3b11a" />
