### PR TITLE
LaunchDarkly連携ステータスページの追加

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,10 @@ const locale = process.env.DOCUSAURUS_CURRENT_LOCALE || 'en';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "SaaSus Platform Document",
+  customFields: {
+    // LaunchDarkly Client-side ID
+    ldClientId: '636a8c5b9d373510aae2dbed',
+  },
   // tagline: 'SaaSus Platform are cool',
   favicon: "img/favicon.ico",
 
@@ -186,6 +190,11 @@ const config = {
             position: "left",
             sidebarId: "changelogSidebar",
             label: "Changelog",
+          },
+          {
+            to: "/status",
+            position: "left",
+            label: "Status",
           },
           {
             type: "localeDropdown",

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -1,4 +1,52 @@
 {
+  "status.title": {
+    "message": "ステータス",
+    "description": "Status page title"
+  },
+  "status.description": {
+    "message": "SaaSus Platform サービスステータス",
+    "description": "Status page meta description"
+  },
+  "status.heading": {
+    "message": "SaaSus Platform ステータス",
+    "description": "Status page heading"
+  },
+  "status.subheading": {
+    "message": "システムの稼働状況を確認できます",
+    "description": "Status page subheading"
+  },
+  "status.operational": {
+    "message": "すべてのシステムが正常に稼働しています",
+    "description": "All systems operational message"
+  },
+  "status.outage": {
+    "message": "システムで問題が発生しています",
+    "description": "System outage message"
+  },
+  "status.incident.title": {
+    "message": "障害情報",
+    "description": "Incident info section title"
+  },
+  "status.incident.message": {
+    "message": "現在、一部のサービスで問題が発生しています。エンジニアチームが復旧作業を行っており、できる限り早く通常の状態に戻るよう対応しております。ご不便をおかけして申し訳ございません。",
+    "description": "Incident description message"
+  },
+  "status.incident.startTime": {
+    "message": "発生時刻:",
+    "description": "Incident start time label"
+  },
+  "status.incident.affectedServices": {
+    "message": "影響範囲:",
+    "description": "Affected services label"
+  },
+  "status.incident.statusText": {
+    "message": "対応状況:",
+    "description": "Status text label"
+  },
+  "status.contact": {
+    "message": "お問い合わせ: support@saasus-platform.com",
+    "description": "Contact info"
+  },
   "theme.ErrorPageContent.title": {
     "message": "エラーが発生しました",
     "description": "The title of the fallback page when the page crashed"

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -43,10 +43,6 @@
     "message": "対応状況:",
     "description": "Status text label"
   },
-  "status.contact": {
-    "message": "お問い合わせ: support@saasus-platform.com",
-    "description": "Contact info"
-  },
   "theme.ErrorPageContent.title": {
     "message": "エラーが発生しました",
     "description": "The title of the fallback page when the page crashed"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-plugin-image-zoom": "^3.0.1",
+        "launchdarkly-react-client-sdk": "^3.9.0",
+        "lucide-react": "^1.8.0",
         "prism-react-renderer": "^2.4.1",
         "punycode": "^2.3.1",
         "react": "^18.0.0",
@@ -12679,6 +12681,48 @@
         "shell-quote": "^1.8.1"
       }
     },
+    "node_modules/launchdarkly-js-client-sdk": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.9.1.tgz",
+      "integrity": "sha512-5mq/eHZxOoxptTJMgpHKHVHrSNZ3GsNv4Kn493UIMt6hRXfHrX0QjBRWACOCTWMt/MkGdKvtN4LOqEHIttKMbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "launchdarkly-js-sdk-common": "5.8.0"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.8.0.tgz",
+      "integrity": "sha512-9X70K3kN1fuR6ZnRudkH7etMgFhi3sEU0mnJ+y2nhID+DpfkNDVnYUGnUs8/s4tsSDs7Q7Gpm4qnr3oqOqT9+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^8.0.0"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
+    "node_modules/launchdarkly-react-client-sdk": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.9.0.tgz",
+      "integrity": "sha512-Ayw6v5nfT0YoshUI89YH7lkOu+qAEtp9t743+dS6xnFq1IVOnckFlz4AoHa6smVjC3nPzj5n0dCLsRVfVIVEOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2",
+        "launchdarkly-js-client-sdk": "^3.9.0",
+        "lodash.camelcase": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.3 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -12753,6 +12797,12 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12838,6 +12888,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lunr": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
+    "launchdarkly-react-client-sdk": "^3.9.0",
+    "lucide-react": "^1.8.0",
     "prism-react-renderer": "^2.4.1",
     "punycode": "^2.3.1",
     "react": "^18.0.0",

--- a/src/pages/status.module.css
+++ b/src/pages/status.module.css
@@ -1,0 +1,91 @@
+/**
+ * CSS files with the .module.css suffix will be treated as CSS modules
+ * and scoped locally.
+ */
+
+.main {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.heading {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.subheading {
+  color: var(--ifm-color-secondary-darkest);
+  margin-bottom: 2rem;
+}
+
+.loading {
+  color: var(--ifm-color-secondary-darkest);
+}
+
+/* 正常時 */
+.operationalCard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 2px solid #bbf7d0;
+  background: #f0fdf4;
+}
+
+.operationalText {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #16a34a;
+}
+
+/* 障害時 */
+.outageCard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 2px solid #fecaca;
+  background: #fef2f2;
+  margin-bottom: 1.5rem;
+}
+
+.outageText {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #dc2626;
+}
+
+.incidentCard {
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+}
+
+.incidentTitle {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #7f1d1d;
+  margin-bottom: 0.75rem;
+}
+
+.incidentMessage {
+  color: #991b1b;
+  margin-bottom: 1rem;
+}
+
+.incidentDetails {
+  font-size: 0.875rem;
+  color: #991b1b;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.incidentDetails p {
+  margin: 0;
+}

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import Layout from '@theme/Layout';
+import Translate, { translate } from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { LDProvider, useFlags, useLDClient } from 'launchdarkly-react-client-sdk';
+import { CheckCircle2, XCircle } from 'lucide-react';
+import styles from './status.module.css';
+
+interface IncidentFlag {
+  enabled?: boolean;
+  startTimeJa?: string;
+  startTimeEn?: string;
+  affectedServicesJa?: string;
+  affectedServicesEn?: string;
+  statusTextJa?: string;
+  statusTextEn?: string;
+}
+
+function StatusContent() {
+  const { i18n: { currentLocale } } = useDocusaurusContext();
+  const ldClient = useLDClient();
+  const { saasusPlatformMaintenancemode } = useFlags();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (!ldClient) return;
+    ldClient.waitForInitialization().then(() => setIsReady(true));
+  }, [ldClient]);
+
+  const incident: IncidentFlag | null | undefined = !isReady ? undefined : saasusPlatformMaintenancemode?.enabled ? saasusPlatformMaintenancemode : null;
+
+  const locale = currentLocale === 'ja' ? 'ja' : 'en';
+
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.heading}>
+        <Translate id="status.heading">SaaSus Platform Status</Translate>
+      </h1>
+      <p className={styles.subheading}>
+        <Translate id="status.subheading">Check the current status of our systems.</Translate>
+      </p>
+
+      {incident === undefined ? (
+        <div className={styles.loading}>Loading...</div>
+      ) : incident === null ? (
+        <div className={styles.operationalCard}>
+          <CheckCircle2 size={32} color="#16a34a" />
+          <div className={styles.operationalText}>
+            <Translate id="status.operational">All systems are operational.</Translate>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className={styles.outageCard}>
+            <XCircle size={32} color="#dc2626" />
+            <div className={styles.outageText}>
+              <Translate id="status.outage">We are experiencing issues with some systems.</Translate>
+            </div>
+          </div>
+
+          <div className={styles.incidentCard}>
+            <div className={styles.incidentTitle}>
+              <Translate id="status.incident.title">Incident Report</Translate>
+            </div>
+            <p className={styles.incidentMessage}>
+              <Translate id="status.incident.message">
+                Some services are currently experiencing issues. Our engineering team is working on a fix and will restore normal operations as soon as possible. We apologize for the inconvenience.
+              </Translate>
+            </p>
+            <div className={styles.incidentDetails}>
+              <p>
+                <strong><Translate id="status.incident.startTime">Start Time:</Translate></strong>{' '}
+                {locale === 'ja' ? (incident.startTimeJa ?? '') : (incident.startTimeEn ?? '')}
+              </p>
+              <p>
+                <strong><Translate id="status.incident.affectedServices">Affected Services:</Translate></strong>{' '}
+                {locale === 'ja' ? (incident.affectedServicesJa ?? '') : (incident.affectedServicesEn ?? '')}
+              </p>
+              <p>
+                <strong><Translate id="status.incident.statusText">Status:</Translate></strong>{' '}
+                {locale === 'ja' ? (incident.statusTextJa ?? '') : (incident.statusTextEn ?? '')}
+              </p>
+            </div>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}
+
+export default function StatusPage() {
+  const { siteConfig } = useDocusaurusContext();
+  const ldClientId = siteConfig.customFields?.ldClientId as string;
+
+  return (
+    <Layout
+      title={translate({ id: 'status.title', message: 'Status' })}
+      description={translate({ id: 'status.description', message: 'SaaSus Platform Service Status' })}
+    >
+      <LDProvider clientSideID={ldClientId}>
+        <StatusContent />
+      </LDProvider>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## 概要
ナビバーにStatusリンクを追加し、LaunchDarklyのフラグで正常/障害を切り替えられるステータスページを実装しました。

## 主な変更
- `src/pages/status.tsx` : ステータスページ新規作成
- `src/pages/status.module.css` : スタイル
- `docusaurus.config.js` : ナビバーへのStatusリンク追加、LaunchDarkly Client-side IDの設定

## 動作
LaunchDarklyの `saasus-platform-maintenancemode` フラグをONにし、以下のJSONを設定するとエラー画面が表示される


```
{
  "affectedServicesEn": "API, Storage, CDN services",
  "affectedServicesJa": "API、ストレージ、CDNサービス",
  "enabled": true,
  "startTimeEn": "April 9, 2026 14:30 JST",
  "startTimeJa": "2026年4月9日 14:30 JST",
  "statusTextEn": "Investigating",
  "statusTextJa": "調査・復旧作業中"
}
```




## 日英対応
- `/status` : 英語表示
- `/ja/status` : 日本語表示
- 障害情報テキストはLaunchDarklyのJSONキー（`startTimeJa` / `startTimeEn` 等）で言語別に管理

## 画像

 - 正常 ja
 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e2f6ac94-1cb9-482c-a726-f890f8ba9dbe" />

 - 正常 en

<img width="600" alt="image" src="https://github.com/user-attachments/assets/51670fb2-8152-42bd-bcf1-fb3b56bf273d" />

 - 障害 ja
 
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/3ff86b06-ba9b-4c78-9fa6-8a5f64718e20" />

 - 障害 en
 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/013fa712-0c46-4a6e-a63a-a14464d65a34" />



# Check List

- [ ] 画像の追加・変更を行っている場合、wikiに記載している [ルール](https://github.com/Anti-Pattern-Inc/saasus-platform-document/wiki/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88%E4%BD%9C%E6%88%90%E3%83%AB%E3%83%BC%E3%83%AB%EF%BC%88%E8%A8%98%E8%BC%89%E4%B8%AD%EF%BC%89)に準拠していることを確認した
