### PR TITLE
ci: knowledge.ja.txt を Google Drive へ自動反映するワークフロー追加

### DIFF
--- a/.github/workflows/update-gem-knowledge.yml
+++ b/.github/workflows/update-gem-knowledge.yml
@@ -1,0 +1,81 @@
+name: Update Gem Knowledge (Google Drive)
+
+# Gem 用ナレッジ static/ai-reference/knowledge.ja.txt を Google Drive の
+# 既存ファイル(KNOWLEDGE_DRIVE_FILE_ID)へ上書き反映するワークフロー。
+#
+# 必要な GitHub Secrets:
+#   KNOWLEDGE_GCP_CREDENTIALS ... Google Cloud サービスアカウントキー(JSON文字列)
+#   KNOWLEDGE_DRIVE_FILE_ID   ... 反映先の Google Drive ファイル ID
+#
+# 前提: 上記サービスアカウントに対象ファイルの編集権限が付与されていること。
+
+on:
+  # main への push で knowledge.ja.txt が更新されたら自動反映
+  push:
+    branches: [main]
+    paths:
+      - static/ai-reference/knowledge.ja.txt
+  # 手動実行も可能
+  workflow_dispatch:
+
+# 同時実行を1つに制限(古い実行はキャンセル)
+concurrency:
+  group: update-gem-knowledge
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-drive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.KNOWLEDGE_GCP_CREDENTIALS }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/drive
+
+      - name: Update knowledge.ja.txt on Google Drive
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          FILE_ID: ${{ secrets.KNOWLEDGE_DRIVE_FILE_ID }}
+          SRC: static/ai-reference/knowledge.ja.txt
+        run: |
+          set -euo pipefail
+
+          if [ -z "${FILE_ID}" ]; then
+            echo "::error::secret KNOWLEDGE_DRIVE_FILE_ID is empty"
+            exit 1
+          fi
+          if [ ! -f "${SRC}" ]; then
+            echo "::error::${SRC} not found"
+            exit 1
+          fi
+
+          echo "Uploading ${SRC} ($(wc -c < "${SRC}") bytes) to Drive file ${FILE_ID}"
+
+          # Drive API v3: 既存ファイルの本文(メディア)を上書き更新する
+          # supportsAllDrives=true で共有ドライブ上のファイルにも対応
+          http_code=$(curl -sS -w '%{http_code}' -o /tmp/drive_resp.json \
+            -X PATCH \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: text/plain; charset=UTF-8" \
+            --data-binary @"${SRC}" \
+            "https://www.googleapis.com/upload/drive/v3/files/${FILE_ID}?uploadType=media&supportsAllDrives=true&fields=id,name,mimeType,modifiedTime,size")
+
+          echo "Drive API response (HTTP ${http_code}):"
+          cat /tmp/drive_resp.json || true
+          echo
+
+          if [ "${http_code}" != "200" ]; then
+            echo "::error::Google Drive update failed (HTTP ${http_code})"
+            exit 1
+          fi
+
+          echo "✅ Updated Google Drive file ${FILE_ID} with ${SRC}"


### PR DESCRIPTION
## 概要
Gem 公開に利用している `static/ai-reference/knowledge.ja.txt` を、`main` への push で更新された際に Google Drive の指定ファイルへ自動反映する GitHub Actions ワークフローを追加します。

## 変更内容
- `.github/workflows/update-gem-knowledge.yml` を追加
  - トリガー: `main` への push で `static/ai-reference/knowledge.ja.txt` が変更されたとき／手動実行(`workflow_dispatch`)
  - 認証: `google-github-actions/auth@v2` + Secret `KNOWLEDGE_GCP_CREDENTIALS`(サービスアカウントキーJSON)
  - 反映: Drive API v3 `files.update`(`uploadType=media`, `supportsAllDrives=true`)で Secret `KNOWLEDGE_DRIVE_FILE_ID` の既存ファイル本文を上書き
  - HTTPステータスを判定し200以外は失敗

## 前提
- サービスアカウントに対象 Drive ファイルの編集権限があること
- 対象ファイルはプレーンテキスト(.txt)であること
- 反映対象はコミット済みの `knowledge.ja.txt`(docs更新時に `make merge_gem` を実行してコミットする運用が前提)

## 動作確認
- ワークフローYAMLの構文検証済み(js-yamlでパース確認)
- 実行はマージ後に `workflow_dispatch` での疎通確認を推奨

## 対象範囲
- 日本語版(`knowledge.ja.txt`)のみ。英語版は対象外。

## Check List
- [x] 画像の追加・変更なし